### PR TITLE
Add default python3 path to gam install script

### DIFF
--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -224,6 +224,11 @@ fi
 $pycmd -V >/dev/null 2>&1
 rc=$?
 if (( $rc != 0 )); then
+  pycmd="/usr/bin/python3"
+fi
+$pycmd -V >/dev/null 2>&1
+rc=$?
+if (( $rc != 0 )); then
   pycmd="python2"
 fi
 $pycmd -V >/dev/null 2>&1


### PR DESCRIPTION
Part of the cascade which checks which python version the user has installed.